### PR TITLE
[Update] group_invite link

### DIFF
--- a/static/js/groups/group_invite.js
+++ b/static/js/groups/group_invite.js
@@ -10,8 +10,14 @@ function copyToClipboard(text) {
 const inviteBtn = document.getElementById('invite-btn');
 const groupId = inviteBtn.dataset.groupId;
 
+// function copyLink() {
+//   const url = `http://ec2-3-106-87-11.ap-southeast-2.compute.amazonaws.com:8000/groups/${groupId}/join`;
+//   copyToClipboard(url);
+//   alert("초대링크가 복사되었습니다.");
+// }
 function copyLink() {
-  const url = `http://ec2-3-106-87-11.ap-southeast-2.compute.amazonaws.com:8000/groups/${groupId}/join`;
+  const currentDomain = window.location.host;
+  const url = `http://${currentDomain}/groups/${groupId}/join`;
   copyToClipboard(url);
   alert("초대링크가 복사되었습니다.");
 }


### PR DESCRIPTION
개인적으로 배포를 다시 해봄. 초대링크가 기존 배포 사이트 링크로 되어 있어 이슈 발생.
그룹 초대하기의 링크 부분을 기존 배포 사이트 링크에서 현재 서버의 URL을 동적으로 생성하도록 변경.